### PR TITLE
Audio adapter feature: specification and plan (001)

### DIFF
--- a/specs/001-rust-audio-adapter/checklists/requirements.md
+++ b/specs/001-rust-audio-adapter/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Audio Adapter Library
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-15
+**Feature**: [specs/001-rust-audio-adapter/spec.md](specs/001-rust-audio-adapter/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - *Review*: The original title referenced Rust (an implementation language); it has been removed. PipeWire/PulseAudio compatibility appears as a functional requirement because it defines the supported audio-server boundary from the feature description; it is treated as a compatibility target rather than an implementation technology choice.
+- [x] Focused on user value and business needs
+  - *Review*: User stories are framed around enabling dictation and improving transcription quality for end users.
+- [x] Written for non-technical stakeholders
+  - *Review*: Language avoids code-level detail and focuses on capabilities, outcomes, and acceptance scenarios.
+- [x] All mandatory sections completed
+  - *Review*: User Scenarios & Testing, Requirements, Success Criteria, and Assumptions are present and populated.
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+  - *Review*: No clarification markers were needed; reasonable defaults are documented in the Assumptions section.
+- [x] Requirements are testable and unambiguous
+  - *Review*: Each functional requirement includes observable behavior; user stories contain concrete acceptance scenarios.
+- [x] Success criteria are measurable
+  - *Review*: Time, error rate, latency, and accuracy metrics include numeric thresholds or comparative baselines.
+- [x] Success criteria are technology-agnostic (no implementation details)
+  - *Review*: Criteria are expressed as user/system observable outcomes (capture start time, latency, accuracy, resource release time).
+- [x] All acceptance scenarios are defined
+  - *Review*: Each user story includes Given/When/Then scenarios covering normal and error paths.
+- [x] Edge cases are identified
+  - *Review*: Edge cases cover device disconnection, permission denial, format mismatch, early stop, concurrent use, and buffer errors.
+- [x] Scope is clearly bounded
+  - *Review*: Scope covers capture, conversion, optional preprocessing, and session lifecycle; upstream consumer responsibilities and secure-field handling are explicitly out of scope.
+- [x] Dependencies and assumptions identified
+  - *Review*: Assumptions section documents target format default, audio server presence, consumer responsibilities, and privacy expectations.
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+  - *Review*: Functional requirements map to acceptance scenarios in user stories or standalone edge cases.
+- [x] User scenarios cover primary flows
+  - *Review*: P1 covers capture/streaming, P2 covers format conversion, P3 covers optional preprocessing.
+- [x] Feature meets measurable outcomes defined in Success Criteria
+  - *Review*: Success criteria align with requirements and can be verified independently of implementation.
+- [x] No implementation details leak into specification
+  - *Review*: No programming languages, build systems, internal module names, or framework choices appear in requirements or success criteria.
+
+## Notes
+
+- All quality checklist items pass. The specification is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/001-rust-audio-adapter/contracts/audio-adapter-api.md
+++ b/specs/001-rust-audio-adapter/contracts/audio-adapter-api.md
@@ -1,0 +1,133 @@
+# Contract: `myna-audio-adapter` Public API
+
+**Feature**: `001-rust-audio-adapter` | **Type**: Rust library API (the crate's external interface)
+
+This is the contract the Speech Controller (and tests) program against. Signatures are normative in shape; exact generics/lifetimes may be refined without changing observable behavior. Types referenced here are defined in [data-model.md](../data-model.md). The "Known consumer" section below pins the subset of this surface the Speech Controller actually uses — API changes must keep that section and its consumer-scenario test in sync (FR-020).
+
+## Entry points
+
+```rust
+/// Enumerate audio-producing input nodes with metadata (FR-002, clarification on enumeration).
+/// Errors: Backend (server unreachable).
+pub fn enumerate_nodes() -> Result<Vec<InputNode>, Error>;
+
+/// Ensure a capture stream is open on the selected node and return its handle (FR-003).
+/// Idempotent: if the node already has an open stream, returns the existing handle; the
+/// provided config MUST NOT alter the already-open stream.
+/// Errors: NoDevice, PermissionDenied, UnsupportedFormat, Backend (FR-012).
+/// Postcondition: first frame is readable within 100 ms on reference hardware (SC-001).
+pub fn open_stream(config: &StreamConfig) -> Result<AudioStream, Error>;
+```
+
+## `AudioStream`
+
+```rust
+impl AudioStream {
+    /// Non-blocking: drain whatever is buffered (possibly empty).
+    /// Items appear in timeline order; StreamEvents are interleaved at the position
+    /// in the timeline where they occurred.
+    pub fn read(&mut self) -> Result<Vec<StreamItem>, Error>;
+
+    /// Blocking with bound: wait until at least one item is available or the timeout elapses.
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<Vec<StreamItem>, Error>;
+
+    /// The node this stream captures from.
+    pub fn node(&self) -> &InputNode;
+
+    /// The configured target format; every AudioFrame matches it (FR-004/FR-005).
+    pub fn target_format(&self) -> AudioFormat;
+
+    /// Close: stop delivery, release the audio source, clear buffers (FR-008).
+    /// Completes within 200 ms (SC-004). Also invoked by Drop.
+    pub fn close(self);
+}
+
+pub enum StreamItem {
+    Frame(AudioFrame),
+    Event(StreamEvent),
+}
+```
+
+### Optional async adapter (feature = "async")
+
+```rust
+impl AudioStream {
+    /// futures::Stream<Item = Result<StreamItem, Error>> over the same core.
+    pub fn into_stream(self) -> impl futures_core::Stream<Item = Result<StreamItem, Error>>;
+}
+```
+
+## Known consumer: Speech Controller (dictation client)
+
+The primary consumer is the Speech Controller defined in `docs/architecture/UD129 - Ubuntu Desktop STT Integration.md`. This section pins the exact API surface it uses (FR-020); the consumer-scenario test (`tests/consumer_scenario.rs`) exercises this surface in this call pattern and MUST break if any of it changes incompatibly.
+
+**Consumer surface** (everything the Speech Controller touches — nothing else in the crate is consumer-facing):
+
+| Speech Controller responsibility (UD129) | API surface used |
+|---|---|
+| Microphone selection in Settings UI | `enumerate_nodes()` → `InputNode { id, name, description, is_default, supported_formats }`; persists `name`, re-resolves at session start |
+| Session start (hotkey press → `Starting`) | `open_stream(&StreamConfig { node, target_format, preprocess, .. })`; first frame ≤ 100 ms (G9) covers the "capture within 100 ms" UD129 target |
+| Stream audio frames to Inference Snap (`Recording`/`Transcribing`) | loop: `read_timeout(d)` → forward `StreamItem::Frame(AudioFrame)` payloads; or `into_stream()` (feature `async`) in an async orchestrator |
+| Utterance chunking / finalization hints | `StreamItem::Event(VoiceActivity { speaking, at })` (feature `vad`) |
+| Diagnostics without raw audio | `Overrun { dropped }` / `Underrun { filled }` events; timing metadata on frames |
+| Error states shown to user (no mic, permission denied) | `Error::NoDevice`, `Error::PermissionDenied` from `open_stream` |
+| Mic unavailable mid-session → stop and notify (UD129 failure handling) | `StreamItem::Event(DeviceLost)` then stream is closed; controller ends the session |
+| Session end / cancellation (hotkey release → buffers discarded) | `close()`; ≤ 200 ms, buffers cleared (G8) covers UD129 "discard in-memory audio buffer" |
+
+**Canonical consumer call sequence** (the shape `tests/consumer_scenario.rs` asserts):
+
+```rust
+// settings time
+let nodes = enumerate_nodes()?;                       // populate device picker
+// hotkey pressed
+let mut stream = open_stream(&config)?;               // Starting → Recording
+while session_active {                                 // Recording/Transcribing
+    for item in stream.read_timeout(FRAME_WAIT)? {
+        match item {
+            StreamItem::Frame(f) => inference.send(f.data),      // stream to Inference Snap
+            StreamItem::Event(VoiceActivity { speaking: false, .. }) => chunk_utterance(),
+            StreamItem::Event(DeviceLost { .. }) => { end_session_with_error(); }
+            StreamItem::Event(_) => log_diagnostics(),           // Overrun/Underrun
+        }
+    }
+}
+// hotkey released (or cancelled)
+stream.close();                                        // Finalizing → Idle; buffers cleared
+```
+
+**Explicitly not consumer surface**: `BackendSelector` override (test hook), `MockBackend`, the `AudioBackend`/`PreprocessStage` traits, ring-buffer internals. Changes there are invisible to the Speech Controller by design.
+
+## Behavioral guarantees (contract tests assert these)
+
+| # | Guarantee | Source |
+|---|---|---|
+| G1 | Every `AudioFrame` matches `target_format` exactly, regardless of source format | FR-004/FR-005, US2-1 |
+| G2 | Frames are contiguous and non-overlapping: `timestamp[n+1] == timestamp[n] + duration[n]`, `seq` has no gaps | FR-013 |
+| G3 | Buffer full ⇒ oldest frames dropped, exactly one `Overrun{dropped}` event per loss span, smoothed splice (no clicks/clipping) | FR-014/FR-015 |
+| G4 | Server underrun ⇒ silence fill keeps timeline continuous + one `Underrun{filled}` event; fill boundaries smoothed (no clipping artifacts) | FR-018/FR-015 |
+| G5 | Node lost while open ⇒ `DeviceLost` event delivered, stream closed, resources released; the library never retargets on its own | FR-016 |
+| G6 | Mid-stream source format change ⇒ transparent renegotiation, uninterrupted target-format delivery; `UnsupportedFormat` error only if unconvertible | FR-017, US2-3 |
+| G7 | `open_stream` on an already-open node is a no-op returning the existing stream | FR-003 |
+| G8 | After `close()`, no frames are delivered; buffers cleared; source released within 200 ms | FR-008, SC-004 |
+| G9 | First frame available ≤ 100 ms after `open_stream` (reference hardware) | SC-001 |
+| G10 | End-to-end latency ≤ 100 ms behind real time under normal load | SC-003 |
+| G11 | With VAD enabled, `VoiceActivity{speaking:false}` fires when speech stops | US3-2 |
+| G12 | With preprocessing disabled, converted frames pass through with no added latency stages | US3-3 |
+| G13 | No audio is written to disk by the library; buffers bounded by `max_buffer_duration` | FR-007 |
+| G14 | No network access required for any code path | SC-006 |
+| G15 | The Speech Controller consumer surface (section above) works end-to-end in the canonical call sequence: enumerate → open → read loop with events → close | FR-020 |
+
+## Feature flags
+
+| Feature | Default | Adds |
+|---|---|---|
+| `pipewire` | yes | Native PipeWire backend (primary) |
+| `pulse` | yes | PulseAudio fallback backend |
+| `vad` | no | Silero VAD preprocessing stage + `VoiceActivity` events |
+| `denoise` | no | RNNoise (`nnnoiseless`) preprocessing stage |
+| `async` | no | `futures::Stream` adapter |
+| `test-util` | no | `MockBackend` for consumer/test use — not part of the consumer surface |
+
+## Stability
+
+Pre-1.0 (`0.x`): breaking API changes allowed with minor-version bumps, tracked in CHANGELOG. The `StreamItem`/`StreamEvent`/`Error` enums are `#[non_exhaustive]` so variants can be added without breakage.

--- a/specs/001-rust-audio-adapter/data-model.md
+++ b/specs/001-rust-audio-adapter/data-model.md
@@ -1,0 +1,115 @@
+# Data Model: Audio Adapter Library
+
+**Feature**: `001-rust-audio-adapter` | **Date**: 2026-07-15
+
+Entities are expressed as Rust-flavored types for precision; names are normative, exact field types may be refined during implementation.
+
+## InputNode
+
+An audio-producing node or source exposed by the audio server (physical microphone, monitor, virtual node). From FR-002 and the node-enumeration clarification.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `NodeId` (opaque, backend-scoped) | Unique within a backend session; not persistent across server restarts |
+| `name` | `String` | Stable machine name (e.g. `alsa_input.pci-0000_00_1f.3.analog-stereo`) |
+| `description` | `String` | Human-readable label for UIs |
+| `is_default` | `bool` | Whether this is the server's current default input |
+| `supported_formats` | `Vec<AudioFormat>` | Rates/formats/channel layouts the node advertises |
+
+**Identity/uniqueness**: `id` is unique per enumeration snapshot; `name` is the quasi-stable key consumers should persist (e.g., in Settings UI).
+
+## AudioFormat
+
+| Field | Type | Notes |
+|---|---|---|
+| `sample_rate` | `u32` (Hz) | e.g. 16_000 |
+| `sample_format` | `SampleFormat` enum: `S16LE`, `F32LE`, … | Target default `S16LE` |
+| `channels` | `u16` | Target default `1` (mono) |
+
+Default target format: **16 kHz, mono, S16LE** (spec Assumptions).
+
+## StreamConfig
+
+Consumer-supplied settings for opening a stream (the spec's "Stream Configuration" entity; the library has streams, not sessions, per the stateless-primitives clarification).
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `node` | `NodeSelector` enum: `Default` \| `ById(NodeId)` \| `ByName(String)` | `Default` | FR-002 |
+| `target_format` | `AudioFormat` | 16 kHz / mono / S16LE | FR-004/FR-005 |
+| `max_buffer_duration` | `Duration` | 10 s | FR-007; bounds the ring buffer |
+| `preprocess` | `PreprocessConfig` | all disabled | FR-010/FR-011 |
+| `backend` | `BackendSelector`: `Auto` \| `PipeWire` \| `Pulse` | `Auto` | testing/override hook |
+
+### PreprocessConfig
+
+| Field | Type | Default |
+|---|---|---|
+| `denoise` | `bool` | `false` |
+| `vad` | `bool` | `false` |
+| `deverb` | `bool` | `false` (reserved; stage deferred per research R6) |
+
+**Validation rules**: `target_format.sample_rate` ∈ [8 kHz, 192 kHz]; `channels` ≥ 1; `max_buffer_duration` > 0; unsupported/unconvertible combinations fail `open_stream` with `Error::UnsupportedFormat` (FR-012).
+
+## AudioStream
+
+Handle to one open capture stream. One per input node (FR-003); `open_stream` on a node with an existing open stream returns the existing handle unchanged (idempotent "ensure open").
+
+**State transitions** (stateless primitives — no session states, FR spec clarification):
+
+```
+(closed) --open_stream--> Open --close()/drop--> (closed)
+                    Open --device lost--> Failed(DeviceLost)   [terminal; resources released]
+                    Open --unconvertible format change--> Failed(UnsupportedFormat)
+```
+
+- `Open → Failed` delivers the error through the read path, closes the underlying server stream, and releases resources (FR-016).
+- Close releases the audio source and clears buffers within 200 ms (FR-008, SC-004).
+- Transparent renegotiation (FR-017) is **not** a state change — the stream stays `Open` and keeps delivering target-format frames.
+
+## AudioFrame
+
+A contiguous chunk of target-format audio with timing metadata (FR-013).
+
+| Field | Type | Notes |
+|---|---|---|
+| `data` | `Bytes`/`Vec<u8>` (interleaved samples in target format) | Always target format |
+| `format` | `AudioFormat` | Echo of the target format |
+| `timestamp` | `Duration` (stream clock, monotonic from stream open) | Start of this frame |
+| `duration` | `Duration` | Derivable from `data.len()`/format; carried for convenience |
+| `seq` | `u64` | Monotonically increasing; no gaps (silence-fill keeps timeline continuous) |
+
+**Invariants**: frames are contiguous and non-overlapping (`timestamp[n+1] = timestamp[n] + duration[n]`, FR-013/FR-018); no audible artifacts across frame boundaries (FR-015).
+
+## StreamEvent
+
+Out-of-band notifications interleaved with frames in the read results.
+
+| Variant | Payload | Source requirement |
+|---|---|---|
+| `Overrun` | `{ dropped: Duration }` | FR-014 (oldest frames dropped) |
+| `Underrun` | `{ filled: Duration }` | FR-018 (synthetic silence span) |
+| `DeviceLost` | `{ node: NodeId }` — terminal, stream closed | FR-016 |
+| `VoiceActivity` | `{ speaking: bool, at: Duration }` | US3 scenario 2 (only when VAD enabled) |
+
+## Error
+
+| Variant | Trigger |
+|---|---|
+| `NoDevice` | No microphone/node available at open (US1 scenario 3) |
+| `PermissionDenied` | Audio server denies capture (FR-012) |
+| `UnsupportedFormat` | Source format cannot be converted to target (FR-012/FR-017) |
+| `DeviceLost` | Node disappeared while stream open (FR-016) |
+| `Backend(String)` | Server connection/protocol failures |
+
+## Relationships
+
+```
+AudioAdapter (library facade)
+ ├── enumerate() ──> Vec<InputNode>
+ ├── open_stream(StreamConfig) ──> AudioStream   (≤1 per InputNode, idempotent)
+ │        AudioStream ──read()──> [AudioFrame | StreamEvent]  (bounded ring, ≤ max_buffer_duration)
+ │        AudioStream ── PreprocessPipeline (0..n PreprocessStage: denoise → vad → [deverb])
+ └── backends: PipeWire (primary) | Pulse (fallback)   [AudioBackend trait]
+```
+
+**Scale assumptions**: single desktop process, ≤ a handful of concurrently open streams, target-format data rate ≈ 32 KB/s (16 kHz × 2 bytes × mono) — 10 s buffer ≈ 320 KB per stream.

--- a/specs/001-rust-audio-adapter/diagrams.md
+++ b/specs/001-rust-audio-adapter/diagrams.md
@@ -1,0 +1,212 @@
+# Diagrams: Audio Adapter Library
+
+**Feature**: `001-rust-audio-adapter` | Satisfies FR-019; diagram 2 documents the known-consumer API surface (FR-020). Cross-references: [data-model.md](data-model.md), [contracts/audio-adapter-api.md](contracts/audio-adapter-api.md) (guarantees G1–G15).
+
+## 1. Architectural block diagram
+
+Components of `myna-audio-adapter` and their relationships. The real-time (RT) side runs on the backend's event-loop thread; the consumer side is whatever thread calls `read()`.
+
+```mermaid
+flowchart LR
+    subgraph consumer["Consumer process (e.g. Speech Controller)"]
+        SC["Consumer"]
+    end
+
+    subgraph crate["myna-audio-adapter"]
+        FACADE["Facade<br/>enumerate_nodes()<br/>open_stream()"]
+        STREAM["AudioStream<br/>read() / read_timeout() / close()"]
+
+        subgraph rt["RT event-loop thread"]
+            BE["AudioBackend trait"]
+            PW["PipeWire backend<br/>(primary)"]
+            PA["PulseAudio backend<br/>(fallback)"]
+            CONV["Convert pipeline<br/>bypass | rubato resample<br/>+ mixdown/format"]
+            PRE["Preprocess chain (optional)<br/>denoise → VAD → (deverb: deferred)"]
+        end
+
+        RING["Bounded SPSC ring buffer<br/>(≤ max_buffer_duration, default 10 s)<br/>drop-oldest + splice smoothing"]
+    end
+
+    subgraph server["Audio server"]
+        SRV["PipeWire / PulseAudio"]
+        NODES["Input nodes<br/>(mics, monitors, virtual)"]
+    end
+
+    SC -->|"open_stream(StreamConfig)"| FACADE
+    FACADE --> BE
+    BE --> PW
+    BE --> PA
+    PW <--> SRV
+    PA <--> SRV
+    SRV --- NODES
+    PW --> CONV
+    PA --> CONV
+    CONV --> PRE
+    PRE -->|"producer"| RING
+    RING -->|"consumer"| STREAM
+    STREAM -->|"Vec&lt;StreamItem&gt;: frames + events"| SC
+```
+
+## 2. Sequence: Speech Controller push-to-talk session over the consumer API surface (G15, FR-020)
+
+How the known primary consumer (Speech Controller, `docs/architecture/UD129`) drives the adapter through one dictation session. Only the API surface shown here is consumer-facing; UD129 session states are on the left.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant SC as Speech Controller
+    participant AA as Audio Adapter (public API)
+    participant INF as Inference Snap
+
+    Note over SC: settings time
+    SC->>AA: enumerate_nodes()
+    AA-->>SC: Vec<InputNode> (id, name, description, formats)
+
+    U->>SC: hotkey press
+    Note over SC: Starting
+    SC->>AA: open_stream(StreamConfig)
+    AA-->>SC: AudioStream (first frame ≤ 100 ms)
+    Note over SC: Recording / Transcribing
+    loop while hotkey held
+        SC->>AA: read_timeout(d)
+        AA-->>SC: [Frame | Event]
+        SC->>INF: frame payloads (streaming)
+        alt Event: VoiceActivity{speaking:false}
+            SC->>INF: finalize / chunk utterance
+        else Event: DeviceLost
+            SC->>SC: end session, notify user
+        else Event: Overrun / Underrun
+            SC->>SC: record diagnostics (no raw audio)
+        end
+    end
+    U->>SC: hotkey release
+    Note over SC: Finalizing → Idle
+    SC->>AA: close()
+    AA-->>SC: source released, buffers cleared ≤ 200 ms
+```
+
+## 3. Sequence: stream open and first-frame delivery (G7, G9)
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant F as Facade
+    participant B as Backend (PipeWire|Pulse)
+    participant S as Audio server
+    participant R as Ring buffer
+
+    C->>F: open_stream(config)
+    F->>F: node already open?
+    alt already open (FR-003)
+        F-->>C: existing AudioStream (no-op)
+    else new stream
+        F->>B: connect + create capture stream
+        B->>S: negotiate target format (server-side convert preferred, FR-009)
+        alt server honors target format
+            S-->>B: stream in target format (convert = bypass)
+        else server cannot honor
+            S-->>B: stream in source format
+            B->>B: enable in-process convert (rubato + mixdown)
+        end
+        S-->>B: audio quantum (RT callback)
+        B->>R: converted target-format frames
+        F-->>C: AudioStream (first frame readable ≤ 100 ms, SC-001)
+    end
+    C->>F: read()
+    F-->>C: [Frame, Frame, ...]
+```
+
+## 4. Sequence: read loop with slow consumer — overrun (G3)
+
+```mermaid
+sequenceDiagram
+    participant S as Audio server (RT)
+    participant R as Ring buffer
+    participant C as Consumer
+
+    loop every audio quantum
+        S->>R: push converted frames
+    end
+    Note over C: consumer stalls...
+    S->>R: push (buffer at capacity)
+    R->>R: drop OLDEST frames (FR-014)<br/>record dropped span<br/>smooth splice boundary (~5 ms fade, FR-015)
+    C->>R: read()
+    R-->>C: [Event: Overrun{dropped}, Frame, Frame, ...]
+    Note over C: timeline stays ordered;<br/>loss is explicit, audio artifact-free
+```
+
+## 5. Sequence: audio-server underrun — silence fill (G4)
+
+```mermaid
+sequenceDiagram
+    participant S as Audio server (RT)
+    participant B as Backend
+    participant R as Ring buffer
+    participant C as Consumer
+
+    S->>B: quantum n
+    B->>R: frames (real audio)
+    Note over S: server delivers nothing<br/>for a short span (underrun)
+    B->>B: detect gap in capture clock
+    B->>R: synthetic silence for missing span (FR-018)<br/>fade real→silence and silence→real (FR-015)
+    S->>B: quantum n+k (audio resumes)
+    B->>R: frames (real audio)
+    C->>R: read()
+    R-->>C: [Frame, Event: Underrun{filled}, Frame(silence), Frame, ...]
+    Note over C: timeline continuous and wall-clock aligned;<br/>silent span flagged as synthetic
+```
+
+## 6. Sequence: input node lost mid-stream (G5)
+
+```mermaid
+sequenceDiagram
+    participant S as Audio server
+    participant B as Backend
+    participant R as Ring buffer
+    participant C as Consumer
+
+    S--)B: node removed (registry event)
+    B->>R: enqueue Event: DeviceLost{node}
+    B->>B: close server stream,<br/>release source, stop RT processing (FR-016)
+    C->>R: read()
+    R-->>C: [...remaining frames, Event: DeviceLost]
+    Note over C: stream is closed/terminal;<br/>consumer decides whether to re-open<br/>on another node — library never retargets
+```
+
+## 7. Sequence: mid-stream source format change — transparent renegotiation (G6)
+
+```mermaid
+sequenceDiagram
+    participant S as Audio server
+    participant B as Backend
+    participant CV as Convert pipeline
+    participant C as Consumer
+
+    S--)B: param-changed: source now 44.1 kHz stereo
+    alt convertible to target
+        B->>CV: reconfigure (new src → target)
+        CV-->>B: ready (no gap in output)
+        Note over C: consumer sees uninterrupted<br/>target-format frames (FR-017) —<br/>no event, no state change
+    else not convertible
+        B->>C: Error: UnsupportedFormat (via read path)
+        B->>B: close stream, release resources
+    end
+```
+
+## 8. Flow: per-quantum data path (G1, G2, G12)
+
+```mermaid
+flowchart TD
+    A["RT capture callback<br/>(source-format samples)"] --> B{"server delivered<br/>target format?"}
+    B -- yes --> D{"preprocessing<br/>enabled?"}
+    B -- no --> C["convert: resample (rubato)<br/>+ channel mixdown + sample format"]
+    C --> D
+    D -- no --> F["frame assembly<br/>(contiguous, seq++, timestamps)"]
+    D -- yes --> E["stage chain:<br/>denoise → VAD(events) → (deverb)"]
+    E --> F
+    F --> G{"ring buffer<br/>full?"}
+    G -- no --> H["push frames"]
+    G -- yes --> I["drop oldest + smooth splice<br/>+ queue Overrun event"]
+    I --> H
+    H --> J["consumer read():<br/>Vec&lt;StreamItem&gt;"]
+```

--- a/specs/001-rust-audio-adapter/plan.md
+++ b/specs/001-rust-audio-adapter/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Audio Adapter Library
+
+**Branch**: `001-rust-audio-adapter` | **Date**: 2026-07-15 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/001-rust-audio-adapter/spec.md`
+
+## Summary
+
+A Rust library (`myna-audio-adapter`) that captures audio from PipeWire/PulseAudio, converts it to a consumer-configured target format (default 16 kHz mono S16LE), and delivers contiguous, artifact-free frames through stateless open/read/close stream primitives — preparing microphone input for the myna dictation pipeline's STT inference backend. Technical approach (from research): a backend trait with a native PipeWire primary implementation and PulseAudio fallback; server-side format negotiation with a `rubato`-based in-process fallback; a lock-free bounded ring buffer with drop-oldest overrun and silence-filled underrun handling (smoothed splices); feature-gated Silero VAD and RNNoise preprocessing stages.
+
+## Technical Context
+
+**Language/Version**: Rust stable ≥ 1.85, edition 2024
+
+**Primary Dependencies**: `pipewire` (pipewire-rs, primary backend), `libpulse-binding` (fallback backend), `rubato` (fallback resampler), `ringbuf` (SPSC ring buffer); feature-gated: `voice_activity_detector` (Silero VAD via onnxruntime), `nnnoiseless` (RNNoise), `futures-core` (async adapter)
+
+**Storage**: N/A — bounded in-memory buffers only; audio is never persisted to disk (FR-007)
+
+**Testing**: `cargo test` — unit tests against a `MockBackend` with WAV fixtures; integration tests against real PipeWire using virtual null-sink nodes (env-gated); latency conformance via example binaries (see research R7, quickstart.md). The full suite also runs in a Canonical Workshop sandbox (`workshop.yaml`) with an isolated audio server — PipeWire or PulseAudio selected at launch — and virtual input devices, host audio untouched (FR-021/FR-022, SC-007/SC-008)
+
+**Target Platform**: Ubuntu Desktop 24.04+ on Linux (Wayland); any Linux with PipeWire ≥ 1.0 or PulseAudio
+
+**Project Type**: Rust library crate in a new Cargo workspace (first crate of the myna repo)
+
+**Performance Goals**: first frame ≤ 100 ms after open (SC-001); end-to-end delivery lag ≤ 100 ms (SC-003); close/release ≤ 200 ms (SC-004); capture callback allocation- and lock-free
+
+**Constraints**: bounded buffers (default 10 s cap, configurable); no disk persistence of audio; no network access (SC-006); no audible artifacts at frame/splice boundaries (FR-015); preprocessing optional and off by default
+
+**Scale/Scope**: single desktop process; ≤ a handful of concurrent streams (one per input node, FR-003); ~32 KB/s per stream at target format
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against Myna Constitution v1.2.0 (staged-delivery gate satisfied by the Branch Staging Plan in tasks.md):
+
+- **I. Red-Green TDD**: contract guarantees G1–G14 (contracts/audio-adapter-api.md) are directly assertable as failing tests before implementation; tasks.md MUST order test tasks before implementation tasks. PASS
+- **II. Integration-test readiness (VM w/ virtual audio interface or real hardware)**: all server interaction sits behind the `AudioBackend` trait; integration suite is env-gated (`MYNA_AUDIO_IT=1`) and driven through a virtual null-sink node (quickstart.md), so the identical tests run on a VM with a virtual audio interface or on real hardware with no code changes; unit/contract suites are hermetic via `MockBackend`. PASS
+- **III. Performance watermarks & regression sensitivity**: performance goals quantified (SC-001/003/004); `capture_check` measures latency conformance. Watermark baselines (peak/steady memory, CPU, latency, buffer occupancy) with declared per-metric tolerances MUST be added as explicit tasks in Phase 2 planning. PASS (with tasking obligation)
+- **IV. Workshop-based development environment**: repo has no `workshop.yaml` yet; creating it (Rust toolchain, libpipewire/libpulse dev headers, audio utilities, audio interface declaration) is a required Setup task for this feature. FR-021/FR-022 additionally make the Workshop sandbox a spec-mandated test execution mode with launch-time PipeWire/PulseAudio backend selection, host isolation, and clean teardown. PASS (with tasking obligation)
+- **V. Privacy-first, offline-first**: bounded in-memory buffers only, no disk persistence (FR-007, G13), no network paths (SC-006, G14). PASS
+
+**Post-Phase-1 re-check**: single library crate, only two trait abstractions (`AudioBackend` mandated by FR-001 dual-server support; `PreprocessStage` mandated by optional/deferred stages FR-010/FR-011); no gate violations. PASS — Complexity Tracking table left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-rust-audio-adapter/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── diagrams.md          # Phase 1 output — architecture block diagram + sequence/flow diagrams (FR-019)
+├── contracts/
+│   └── audio-adapter-api.md   # Public Rust API contract (guarantees G1–G14)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+Cargo.toml                      # new workspace manifest
+workshop.yaml                   # Canonical Workshop dev-environment definition (constitution IV)
+crates/audio-adapter/
+├── Cargo.toml                  # crate: myna-audio-adapter; features: pipewire, pulse, vad, denoise, async
+├── src/
+│   ├── lib.rs                  # public facade: enumerate_nodes(), open_stream()
+│   ├── error.rs                # Error enum (NoDevice, PermissionDenied, UnsupportedFormat, DeviceLost, Backend)
+│   ├── config.rs               # StreamConfig, PreprocessConfig, NodeSelector, BackendSelector
+│   ├── format.rs               # AudioFormat, SampleFormat
+│   ├── node.rs                 # InputNode, NodeId
+│   ├── frame.rs                # AudioFrame, StreamItem, StreamEvent
+│   ├── stream.rs               # AudioStream: read/read_timeout/close, ring-buffer consumer side
+│   ├── ring.rs                 # bounded SPSC ring, drop-oldest, overrun/underrun accounting, splice smoothing
+│   ├── convert/
+│   │   ├── mod.rs              # conversion pipeline (bypass when server delivers target format)
+│   │   ├── resample.rs         # rubato-backed fallback resampler
+│   │   └── channels.rs         # channel mixdown + sample-format conversion
+│   ├── preprocess/
+│   │   ├── mod.rs              # PreprocessStage trait + stage chain
+│   │   ├── denoise.rs          # nnnoiseless stage (feature = "denoise")
+│   │   └── vad.rs              # Silero VAD stage (feature = "vad")
+│   ├── backend/
+│   │   ├── mod.rs              # AudioBackend trait + Auto probe (PipeWire → Pulse)
+│   │   ├── pipewire.rs         # native PipeWire backend (feature = "pipewire")
+│   │   ├── pulse.rs            # PulseAudio fallback backend (feature = "pulse")
+│   │   └── mock.rs             # MockBackend (cfg(test) / test-util feature)
+│   └── async_stream.rs         # futures::Stream adapter (feature = "async")
+├── examples/
+│   ├── capture_check.rs        # latency/lifecycle conformance (quickstart)
+│   └── preprocess_check.rs     # VAD/denoise validation (quickstart)
+└── tests/
+    ├── contract.rs             # G1–G15 assertions against MockBackend
+    ├── consumer_scenario.rs    # Speech Controller call pattern end-to-end (FR-020, G15):
+    │                           #   enumerate → open → read loop w/ events → close
+    ├── integration.rs          # real-PipeWire tests, env-gated (MYNA_AUDIO_IT=1)
+    └── fixtures/               # WAV fixtures (speech_48k_stereo.wav, noisy_speech.wav, …)
+```
+
+**Structure Decision**: New Cargo workspace at repo root with the library under `crates/audio-adapter`, since the repository currently contains only documentation and this is the first of several planned myna components (Speech Controller, Text Injection Layer per docs/architecture). The crate is self-contained; all system integration happens behind the `AudioBackend` trait so contract tests run hermetically.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+*(none — no gate violations)*

--- a/specs/001-rust-audio-adapter/quickstart.md
+++ b/specs/001-rust-audio-adapter/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Audio Adapter Library validation
+
+**Feature**: `001-rust-audio-adapter`
+
+Runnable scenarios proving the feature works end-to-end. Contract guarantees referenced as G1–G14 are defined in [contracts/audio-adapter-api.md](contracts/audio-adapter-api.md); types in [data-model.md](data-model.md).
+
+## Prerequisites
+
+- Ubuntu 24.04+ (or any Linux with PipeWire ≥ 1.0; PulseAudio systems exercise the fallback backend)
+- Rust stable ≥ 1.85 (`rustup default stable`)
+- System packages: `sudo apt install libpipewire-0.3-dev libpulse-dev clang pkg-config pipewire-utils pulseaudio-utils`
+- A working microphone **or** the virtual node from the "Virtual node" section below (CI path)
+
+## Sandboxed run (Canonical Workshop — recommended; FR-021/FR-022)
+
+With only [Workshop](https://ubuntu.com/workshop/docs) installed on the host, the repo's `workshop.yaml` provisions the toolchain, an isolated audio server, and virtual input devices:
+
+```bash
+workshop launch                                   # PipeWire backend (default)
+workshop launch --config backend=pulse            # PulseAudio backend selection (exact knob defined by workshop.yaml)
+workshop exec -- cargo test --all-features        # hermetic suite inside the sandbox
+workshop exec -- env MYNA_AUDIO_IT=1 cargo test --test integration -- --ignored
+```
+
+**Expected**: each backend selection passes 100% of its explicitly declared test subset (SC-007) — PipeWire-only tests (native node enumeration, session-manager routing) belong to the PipeWire subset and do not run under PulseAudio; host audio devices/daemons untouched during and after the run (SC-008); after first-launch provisioning, launches and test runs succeed with no network access; environment failures (Workshop missing, backend failed to start) reported distinctly from test failures. The host-based sections below remain valid for machines where the dependencies are installed directly.
+
+## Build and unit tests (hermetic — MockBackend, no audio server needed)
+
+```bash
+cargo build -p myna-audio-adapter --all-features
+cargo test  -p myna-audio-adapter --all-features
+```
+
+**Expected**: all unit tests pass; suites cover conversion (G1), frame continuity (G2), overrun drop+event+smoothing (G3), underrun silence-fill+event (G4), close semantics (G8), pass-through when preprocessing disabled (G12), and the **consumer-scenario test** (`tests/consumer_scenario.rs`, G15/FR-020) that replays the Speech Controller's push-to-talk call pattern — enumerate → open → timed read loop handling `Frame`/`VoiceActivity`/`DeviceLost`/`Overrun` items → close — against both `MockBackend` and (in the integration suite) the virtual node.
+
+## Virtual node setup (for integration tests without hardware)
+
+```bash
+pactl load-module module-null-sink sink_name=myna_test sink_properties=device.description=MynaTest
+# feed a fixture into the sink; its monitor acts as our capture node
+paplay --device=myna_test tests/fixtures/speech_48k_stereo.wav &
+```
+
+Tear down with `pactl unload-module module-null-sink`.
+
+## Integration tests (real PipeWire)
+
+```bash
+MYNA_AUDIO_IT=1 cargo test -p myna-audio-adapter --test integration -- --ignored
+```
+
+**Expected outcomes** (each maps to a spec scenario):
+
+| Test | Validates |
+|---|---|
+| `enumerates_nodes_with_metadata` | Node list contains the virtual node with id, description, supported formats (FR-002) |
+| `captures_target_format_from_48k_stereo` | 48 kHz stereo source → every frame 16 kHz mono S16LE (US2-1, G1) |
+| `open_is_idempotent_per_node` | Second `open_stream` on same node returns existing stream (FR-003, G7) |
+| `device_lost_closes_stream` | Unload the null-sink module mid-stream → `DeviceLost` event, stream closed (FR-016, G5) |
+| `format_change_renegotiates` | Change source format mid-stream → uninterrupted target-format frames (FR-017, G6) |
+| `no_device_errors_cleanly` | Open with `ByName("nonexistent")` → `Error::NoDevice` (US1-3) |
+| `speech_controller_session_flow` | Full consumer call pattern against the virtual node: enumerate → open → read loop → close, asserting the exact API surface documented in the contract's "Known consumer" section (FR-020, G15) |
+
+## Latency and lifecycle conformance (example binary)
+
+```bash
+cargo run -p myna-audio-adapter --example capture_check
+```
+
+`capture_check` opens the default node, reads for 5 s, closes, and prints measurements.
+
+**Expected**:
+- `first_frame_ms ≤ 100` (SC-001, G9)
+- `steady_state_lag_ms ≤ 100` (SC-003, G10)
+- `close_ms ≤ 200` (SC-004, G8)
+- exit code 0; non-conforming measurements exit non-zero
+
+## Preprocessing validation (feature-gated)
+
+```bash
+cargo run -p myna-audio-adapter --features vad,denoise --example preprocess_check -- tests/fixtures/noisy_speech.wav
+```
+
+**Expected**: `VoiceActivity{speaking:false}` events at silent spans of the fixture (US3-2, G11); denoised output RMS in non-speech regions lower than input, speech regions intact (US3-1). Transcription-accuracy comparison against the unprocessed baseline (SC-005) is a manual/benchmark step documented in `tasks.md`, not part of this quickstart.
+
+## Privacy check
+
+```bash
+strace -f -e trace=openat -o /tmp/audio_trace.log cargo run -p myna-audio-adapter --example capture_check
+grep -v -E '(\.so|\.toml|/proc|/sys|/dev|/run|\.cache/pipewire)' /tmp/audio_trace.log | grep -i -E '(\.wav|\.raw|\.pcm)' && echo "FAIL: audio persisted" || echo "OK: no audio written to disk"
+```
+
+**Expected**: `OK` — no audio files written (FR-007, G13). Also verify `capture_check` runs with networking disabled (`unshare -n`) to confirm SC-006/G14.

--- a/specs/001-rust-audio-adapter/research.md
+++ b/specs/001-rust-audio-adapter/research.md
@@ -1,0 +1,62 @@
+# Research: Audio Adapter Library
+
+**Feature**: `001-rust-audio-adapter` | **Date**: 2026-07-15
+
+All Technical Context unknowns from plan.md are resolved below.
+
+## R1. Audio backend strategy (PipeWire vs PulseAudio vs portability layers)
+
+- **Decision**: Define an internal `AudioBackend` trait with two implementations: a **native PipeWire backend** (via the `pipewire` crate, the official pipewire-rs bindings) as the primary path, and a **PulseAudio backend** (via `libpulse-binding` + `libpulse-simple-binding`) as the fallback for systems running a real PulseAudio daemon. Backend selection is automatic at runtime (probe PipeWire first, fall back to PulseAudio), with an override in `StreamConfig` for testing.
+- **Rationale**:
+  - FR-001 requires both PipeWire- and PulseAudio-compatible servers. Ubuntu 22.10+ ships PipeWire (with `pipewire-pulse` emulating PulseAudio), but PulseAudio-only systems still exist in the support window.
+  - FR-002/the node-enumeration clarification require enumerating *arbitrary audio-producing nodes* (not just microphones) with format metadata — only the native PipeWire registry exposes this fully; the PulseAudio backend enumerates sources (including monitor sources) which covers the same user need on PA systems.
+  - FR-009 prefers native/session-manager routing (WirePlumber) — only available through the native PipeWire API.
+- **Alternatives considered**:
+  - **`libpulse` only** (works against pipewire-pulse too): simplest, but cannot enumerate PipeWire nodes generically, cannot leverage WirePlumber routing, and adds a compat layer on the primary platform. Rejected as primary; kept as fallback.
+  - **`cpal`**: cross-platform, but its Linux story is ALSA-first, node enumeration is weak, and it hides format-renegotiation events we must surface (FR-017). Rejected.
+  - **GStreamer**: capable but a heavyweight dependency tree for a focused capture library. Rejected.
+
+## R2. Resampling and format conversion
+
+- **Decision**: Prefer **server-side negotiation**: request the target format (default 16 kHz / mono / S16LE) directly on the capture stream so PipeWire's `audioconvert`/`audioresample` (or PulseAudio's stream converter) delivers target-format frames natively. When the server cannot honor the target (or changes the source format mid-stream, FR-017), fall back to an **in-process conversion stage**: `rubato` (sinc-interpolation resampler, pure Rust) for sample-rate conversion plus a small hand-rolled sample-format/channel-mixdown step.
+- **Rationale**: Matches the feature input's "native (session manager provided when possible) functionality" requirement (FR-009) and keeps the hot path zero-copy in the common case; `rubato` is the de-facto Rust resampler, real-time-safe (no allocation in `process`), and licence-compatible (MIT).
+- **Alternatives considered**: `libsoxr`/`speexdsp` bindings (C dependencies, packaging burden), `dasp` (no polyphase/sinc resampler of comparable quality), always-in-process conversion (wastes the server's optimized path and contradicts FR-009).
+
+## R3. Buffering, overrun, and underrun handling
+
+- **Decision**: One bounded **SPSC ring buffer** per open stream (via the `ringbuf` crate), sized from `max_buffer_duration` (default 10 s, FR-007). The real-time capture callback is the producer; the consumer pulls via the read API. On overflow the producer drops the **oldest** frames, records the dropped span, and emits an `Overrun` event (FR-014). On server underrun the library inserts **silence** for the missing span and emits an `Underrun` event (FR-018). All splice points (drop boundaries, silence-fill boundaries) get a short raised-cosine fade (~5 ms) to prevent clicks/clipping (FR-015).
+- **Rationale**: SPSC lock-free ring keeps the capture callback allocation- and lock-free (a hard real-time-audio requirement); drop-oldest keeps latency bounded for live dictation; explicit events keep the delivered timeline honest and continuous per the clarifications.
+- **Alternatives considered**: `crossbeam` channels (allocation + unbounded by default), blocking the callback (audio-server stalls, unacceptable), abrupt splices without smoothing (violates FR-015).
+
+## R4. Delivery model (pull API, events, threading)
+
+- **Decision**: **Synchronous pull-based core**: the backend runs its own event-loop thread (PipeWire `MainLoop` / PulseAudio threaded mainloop); the consumer calls `AudioStream::read()` (non-blocking, returns whatever is buffered) or `read_timeout()` (bounded wait). Out-of-band notifications (overrun, underrun, device-lost, voice-activity) are delivered as `StreamEvent`s interleaved in the read results. An optional `async` feature exposes a `futures::Stream` adapter over the same core.
+- **Rationale**: The clarifications fixed a pull model ("consumer pulls at irregular intervals") with stateless open/close primitives; a sync core with an async adapter serves both the Speech Controller (likely async) and tests without forcing a runtime dependency on all consumers.
+- **Alternatives considered**: callback-based push API (inverts control, complicates consumer lifecycle and violates the stateless-primitives decision), mandatory tokio dependency (unnecessary coupling for a leaf library).
+
+## R5. Voice activity detection
+
+- **Decision**: Feature-gated `vad` stage using **Silero VAD** through the `voice_activity_detector` crate (onnxruntime backend). Emits `VoiceActivity { speaking: bool }` stream events on transitions (US3, FR-010).
+- **Rationale**: Silero is the current accuracy standard for lightweight offline VAD, runs comfortably in real time on CPU at 16 kHz, and the ONNX model is redistributable. Feature-gating keeps the onnxruntime dependency out of consumers that disable preprocessing.
+- **Alternatives considered**: `webrtc-vad` (much lighter but markedly worse accuracy, energy-based failure modes in noise), energy-threshold VAD (too crude for utterance chunking), custom DNN (out of scope).
+
+## R6. Noise suppression and dereverberation
+
+- **Decision**: Feature-gated `denoise` stage using **`nnnoiseless`** (pure-Rust RNNoise port, 48 kHz internal rate handled by the conversion stage). Dereverberation (FR-011, MAY) is **deferred**: the preprocessing pipeline is a trait-based stage chain (`PreprocessStage`), so a deverb stage can be added later without API changes; no mature pure-Rust dereverb implementation exists today.
+- **Rationale**: `nnnoiseless` is proven, allocation-free in steady state, and pure Rust (no C build). Deferring deverb honors the MAY requirement without blocking the MVP.
+- **Alternatives considered**: RNNoise C bindings (build complexity for no quality gain), DeepFilterNet (better quality but heavy model + LADSPA/ONNX integration cost — candidate for a later stage behind the same trait), doing nothing (loses FR-010 SHOULD).
+
+## R7. Testing strategy against a real audio server
+
+- **Decision**: Three layers:
+  1. **Unit tests** with a `MockBackend` implementing `AudioBackend`, feeding golden WAV fixtures — covers conversion, ring buffer, overrun/underrun/smoothing, VAD gating, error mapping.
+  2. **Integration tests** against a real PipeWire instance using a **null-sink virtual node** (`pw-cli create-node adapter-factory ... media.class=Audio/Source/Virtual` or `pactl load-module module-null-sink`), driven by `pw-cat`/`paplay` playing fixtures into the monitor — covers enumeration, open/close idempotency, format renegotiation, device-lost (unload the module mid-stream). Gated behind `#[ignore]`/an env var so `cargo test` stays hermetic; CI job starts a headless `pipewire` + `wireplumber`.
+  3. **Latency/conformance checks** in the quickstart (first-frame ≤ 100 ms, close ≤ 200 ms) measured by a small example binary.
+- **Rationale**: The mock keeps the correctness suite fast and deterministic; virtual nodes exercise the real negotiation/registry code paths that mocks cannot; matches the spec's independent-test definitions.
+- **Alternatives considered**: only mocking (misses real server behavior, the historical source of format bugs per US2), requiring physical hardware in CI (non-deterministic, unavailable).
+
+## R8. Toolchain and packaging
+
+- **Decision**: Rust **stable ≥ 1.85, edition 2024**; Cargo **workspace** at repo root with the library at `crates/audio-adapter` (crate name `myna-audio-adapter`). System build deps: `libpipewire-0.3-dev`, `libpulse-dev`, `clang` (bindgen). Features: `pipewire` (default), `pulse` (default), `vad`, `denoise`, `async`.
+- **Rationale**: The repo will host more myna components (Speech Controller, etc.); a workspace from day one avoids restructuring. Feature flags keep the mandatory core (capture + convert) dependency-light per the assumptions about resource constraints.
+- **Alternatives considered**: single crate at repo root (blocks future components), splitting backends into separate crates now (premature).

--- a/specs/001-rust-audio-adapter/spec.md
+++ b/specs/001-rust-audio-adapter/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Audio Adapter Library
+
+**Feature Branch**: `001-rust-audio-adapter`
+
+**Created**: 2026-07-15
+
+**Status**: Draft
+
+**Input**: User description: "I would like to implement a Rust library for a pipewire / pulseaudio compatible reading of audio buffers, resampling it to a target format, sample rate using native (session manager provided when possible) functionality, optionally deverbing it and overall preparing for speech to text model inference. For ideas and requirements with the rest of the system, see https://github.com/canonical/myna/tree/testbed-and-service-api and /Users/mz2/Downloads/audio-adapter-api.md"
+
+## Clarifications
+
+### Session 2026-07-15
+
+- **Q**: What should the upper bound on the rolling buffer be?  
+  **A**: Configurable duration with a default; the default maximum rolling buffer duration is 10 seconds.
+- **Q**: Should the adapter support overlapping audio windows, and who controls that setting?  
+  **A**: No overlapping windows; the adapter delivers contiguous (non-overlapping) frames, and overlapping windowing is out of scope.
+- **Q**: Should the library be session-aware or expose stateless audio primitives?  
+  **A**: Stateless audio primitives only; the caller manages the dictation/session lifecycle and uses the library to open and close an audio stream on demand.
+- **Q**: When the consumer reads frames too slowly and the bounded buffer fills, what should the library do?  
+  **A**: Drop the oldest buffered frames to make room, notify the consumer of the overrun, and apply smoothing at frame boundaries to minimize audible artifacts such as clicks or pops.
+- **Q**: How should the library handle frame boundaries when the consumer pulls at irregular intervals?  
+  **A**: The library MUST avoid clipping, discontinuities, and other audible artifacts across frame boundaries regardless of when the consumer reads.
+- **Q**: Should the library support multiple concurrent open streams?  
+  **A**: One open stream per input audio node; opening a stream is an idempotent "ensure open" operation that is a no-op if the node already has an open stream. The library supports any audio-producing node or sink that the underlying audio server exposes (e.g., PipeWire nodes), not only physical microphones.
+- **Q**: What device / node enumeration should the library provide?  
+  **A**: The library MUST enumerate available input nodes and expose metadata including node identifier, human-readable name/description, and the sample rates/formats the node supports.
+- **Q**: When the selected input node is disconnected while its stream is open, what should the library do?  
+  **A**: Deliver a device-lost error and close the stream; the caller decides whether to re-open on another node.
+- **Q**: When the audio server changes the source format unexpectedly mid-stream, what should the library do?  
+  **A**: Renegotiate transparently and keep delivering target-format frames without interruption; report an error only if the new source format cannot be converted to the target.
+- **Q**: When the audio server momentarily underruns (delivers no samples for a short period), how should the library represent the gap to the consumer?  
+  **A**: Fill the gap with silence so the delivered timeline stays continuous, and notify the consumer that an underrun occurred (the silent span is synthetic). The silence fill itself must not introduce clipping or other audible artifacts at the transitions between real audio and the silent span.
+- **Q**: When the sandbox runs with the PulseAudio backend, how should PipeWire-only tests (native node enumeration, session-manager routing) be handled?  
+  **A**: Maintain explicitly declared per-backend test subsets; the backend matrix runs each backend's declared subset, and results report against that declaration.
+- **Q**: May sandboxed test runs depend on network access?  
+  **A**: Initial provisioning may download and cache dependencies; after that, sandbox launches and all test executions must succeed with no network access.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Open an audio stream and deliver frames for STT (Priority: P1)
+
+The dictation client needs a continuous stream of microphone audio to send to the inference backend. The audio adapter library exposes stateless audio-stream primitives: the consumer opens a capture stream from the selected or default input device, reads frames incrementally while the stream is open, and closes the stream when dictation ends.
+
+**Why this priority**: This is the core capability that enables the rest of the dictation pipeline. Without reliable audio capture and streaming, no speech recognition can occur.
+
+**Independent Test**: Initialize the library, open an audio stream, speak into a microphone, and verify that a downstream test consumer receives a continuous sequence of artifact-free audio frames that can be decoded into intelligible speech.
+
+**Acceptance Scenarios**:
+
+1. **Given** a microphone is available and permission is granted, **When** the consumer opens an audio stream, **Then** the library begins delivering audio frames within 100 ms.
+2. **Given** an open stream, **When** the consumer closes the stream, **Then** the library stops delivering frames, releases the audio source, and clears in-memory buffers.
+3. **Given** no microphone is available, **When** the consumer opens an audio stream, **Then** the library reports an error and does not attempt to deliver frames.
+
+---
+
+### User Story 2 - Resample and format-convert to STT-compatible audio (Priority: P2)
+
+Audio servers may expose microphones at a variety of sample rates, sample formats, and channel counts. The inference backend expects a single, stable input format. The library converts any supported source format into the configured target format so the consumer does not need to handle format negotiation itself.
+
+**Why this priority**: Format negotiation is a common source of integration bugs between desktop audio stacks and inference backends. Centralizing it in the adapter keeps the rest of the system simpler and more robust.
+
+**Independent Test**: Provide a captured or synthetic source stream at a non-target sample rate and channel count, configure a target format, and verify that every delivered frame matches the target format.
+
+**Acceptance Scenarios**:
+
+1. **Given** a microphone source running at 48 kHz stereo, **When** the target is configured to 16 kHz mono, **Then** every delivered audio frame is 16 kHz mono.
+2. **Given** a source that reports an unsupported or unknown format, **When** capture is requested, **Then** the library reports a format error instead of producing invalid audio.
+3. **Given** a running stream, **When** the audio server changes the source format unexpectedly, **Then** the library renegotiates transparently and continues delivering target-format frames without interruption, reporting an error only if the new source format cannot be converted to the target.
+
+---
+
+### User Story 3 - Optional preprocessing for better transcription quality (Priority: P3)
+
+Recorded speech may contain background noise, room reverberation, or long silent passages that reduce transcription accuracy. The library can apply optional preprocessing—such as noise suppression, voice activity detection, and dereverberation—so the inference backend receives cleaner speech.
+
+**Why this priority**: Preprocessing improves accuracy in real-world environments, but it is secondary to the primary capture and conversion pipeline and may be disabled when latency or resource use is critical.
+
+**Independent Test**: Feed noisy or reverberant audio through the library with preprocessing enabled, and verify that silence/non-speech segments are reduced and that downstream transcription accuracy is at least as good as the unprocessed baseline.
+
+**Acceptance Scenarios**:
+
+1. **Given** preprocessing is enabled, **When** a noisy audio stream is captured, **Then** non-speech audio is attenuated or flagged without introducing audible distortion of speech.
+2. **Given** voice activity detection is enabled, **When** the user stops speaking, **Then** the library signals the silence event so the consumer can finalize or chunk utterances appropriately.
+3. **Given** preprocessing is disabled, **When** audio is captured, **Then** the library passes the original converted frames through without additional latency.
+
+### Edge Cases
+
+- Node disconnected while the stream is open: the library delivers a device-lost error and closes the stream; the caller decides whether to re-open on another node (see FR-016).
+- Microphone permission denied: opening the stream fails with a permission error and no frames are delivered (see FR-012).
+- Source sample rate cannot be converted to the target: the library reports a format error instead of producing invalid audio (see FR-012, FR-017).
+- Stream closed before any frames have been delivered: closing is safe at any time; the audio source is released and buffers are cleared (see FR-008).
+- Capture starts while another application is using the same microphone: desktop audio servers support shared capture; the library opens its own stream and neither preempts nor is preempted by the other application.
+- Buffer overrun (slow consumer): when a bounded buffer fills, the library drops the oldest buffered frames, notifies the consumer, and applies smoothing to minimize artifacts (see FR-014).
+- Audio-server underrun: when the audio server momentarily delivers no samples, the library fills the gap with silence to keep the delivered timeline continuous and notifies the consumer that an underrun occurred (see FR-018).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST capture audio from PipeWire- and PulseAudio-compatible audio servers.
+- **FR-002**: The library MUST allow the consumer to discover available input nodes, select a specific input device or any audio-producing node/sink exposed by the audio server when the backend supports it, or fall back to a system-default device.
+- **FR-003**: The library MUST support one open stream per selected input node; opening a stream on a node that already has an open stream MUST be a no-op that leaves the existing stream intact.
+- **FR-004**: The library MUST resample captured audio to the target sample rate configured by the consumer.
+- **FR-005**: The library MUST convert captured audio to the target sample format and channel layout configured by the consumer.
+- **FR-006**: The library MUST deliver audio frames incrementally to the consumer while the stream is open.
+- **FR-007**: The library MUST keep all intermediate audio data in bounded in-memory buffers; the maximum rolling buffer duration MUST be configurable and defaults to 10 seconds. The library MUST NOT persist captured audio to disk by default.
+- **FR-008**: The library MUST release the audio source and flush buffers when the caller closes the stream.
+- **FR-009**: The library SHOULD prefer native or session-manager audio routing functionality when the audio server provides it.
+- **FR-010**: The library SHOULD support optional audio preprocessing, including at least noise suppression and voice activity detection.
+- **FR-011**: The library MAY support optional dereverberation ("deverb") when enabled by the consumer.
+- **FR-012**: The library MUST return a typed `Error` variant (`NoDevice`, `PermissionDenied`, or `UnsupportedFormat`) with sufficient context for the consumer to display a meaningful message when the microphone or selected node is unavailable, permission is denied, or format negotiation fails.
+- **FR-013**: The library MUST deliver contiguous, non-overlapping audio frames while the stream is open; overlapping windowing is out of scope for this feature.
+- **FR-014**: When a bounded buffer reaches capacity because the consumer is not consuming frames quickly enough, the library MUST drop the oldest buffered frames to make room, MUST deliver an explicit overrun notification to the consumer, and MUST apply smoothing at loss boundaries to minimize audible artifacts.
+- **FR-015**: The library MUST avoid clipping, discontinuities, and other audible artifacts across frame boundaries regardless of when or how the consumer reads frames.
+- **FR-016**: When the selected input node is disconnected or otherwise lost while its stream is open, the library MUST deliver a device-lost error to the consumer and close the stream, releasing its resources; the library MUST NOT switch capture to a different node on its own.
+- **FR-017**: When the audio server changes the source format mid-stream, the library MUST renegotiate transparently and continue delivering frames in the configured target format without interruption; it MUST report a format error only if the new source format cannot be converted to the target.
+- **FR-018**: When the audio server momentarily underruns, the library MUST fill the missing span with silence so the delivered timeline remains continuous and wall-clock aligned, and MUST deliver an underrun notification so the consumer knows the silent span is synthetic. The silence fill MUST NOT itself introduce clipping or other audible artifacts: transitions between real audio and the silent span MUST be smoothed per FR-015.
+- **FR-019**: The feature deliverables MUST include visual documentation maintained in version-controlled text form alongside the feature documentation: an architectural block diagram of the library's components and their relationships, and sequence/flow diagrams covering at least stream open and first-frame delivery, the consumer read loop with overrun handling, underrun silence fill, device loss, and mid-stream format renegotiation.
+- **FR-020**: The public API, its documentation, and the test suite MUST demonstrably fit the known primary consumer — the dictation client's Speech Controller (docs/architecture). The documentation MUST identify the exact API surface that consumer uses for its push-to-talk session flow (device selection for settings, session start, incremental streaming reads, event/error handling, session end), and the test suite MUST include a consumer-scenario test that exercises that surface end-to-end in the same call pattern the Speech Controller uses.
+- **FR-021**: The test regime MUST include a sandboxed execution mode based on Canonical Workshop (https://ubuntu.com/workshop/docs, per constitution Principle IV): a version-controlled sandbox definition provisions an isolated audio server — PipeWire or PulseAudio, selectable at launch — together with virtual input devices into which test fixtures can be injected, and the full test suite (hermetic, integration, consumer-scenario, performance conformance) runs inside the sandbox unchanged, with results recording which backend was exercised. Tests that apply to only one backend MUST belong to an explicitly declared per-backend test subset; the backend matrix runs each backend's declared subset and reports results against that declaration.
+- **FR-022**: Sandboxed test runs MUST NOT access, modify, or depend on the host's audio devices, daemons, or configuration; teardown MUST leave no audio daemons, virtual devices, or test state on the host. The sandbox MUST run non-interactively for automation, and environment/provisioning failures (Workshop missing, virtualization unavailable, backend failed to start) MUST be reported distinctly from test failures. Initial sandbox provisioning MAY download and cache dependencies; once provisioned, sandbox launches and all test executions MUST succeed without network access.
+
+### Key Entities *(include if feature involves data)*
+
+- **Audio Adapter**: The library component that manages capture, format conversion, optional preprocessing, and the lifecycle of an audio stream on behalf of the caller.
+- **Audio Frame**: A discrete chunk of audio data in the target format, delivered to the consumer together with timing metadata.
+- **Stream Configuration**: The consumer-supplied settings for target sample rate, sample format, channels, input node selection, preprocessing options, and maximum rolling buffer duration.
+- **Audio Source**: The microphone or input stream provided by the desktop audio server.
+- **Preprocessing Pipeline**: The optional set of audio enhancement stages applied before frames are delivered.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The library begins delivering audio frames within 100 ms of the consumer opening a stream on the constitution's named reference environments.
+- **SC-002**: Resampled audio output matches the configured target sample rate and channel layout, and the total sample error versus a high-quality reference resampling of the same source is below 1% over a reference clip.
+- **SC-003**: Audio frames are delivered to the consumer with end-to-end latency no greater than 100 ms behind real time under normal system load.
+- **SC-004**: Closing the audio stream releases all audio resources and clears in-memory buffers within 200 ms.
+- **SC-005**: When preprocessing is enabled, transcription accuracy on a reference noisy/reverberant corpus is at least as high as the unprocessed baseline.
+- **SC-006**: The library produces a usable audio stream for dictation sessions without requiring network connectivity.
+- **SC-007**: Inside the Workshop sandbox, each backend selection (PipeWire and PulseAudio) passes 100% of its explicitly declared test subset, and a developer with only Workshop installed reaches a completed sandboxed test run with at most two documented commands.
+- **SC-008**: During and after a sandboxed test run, zero changes are observable in the host's audio devices, daemons, or configuration.
+
+## Assumptions
+
+- The consumer configures a target format suitable for the chosen inference backend; the default target represents a common speech-to-text input format (16 kHz sample rate, mono, 16-bit PCM).
+- The consumer is responsible for dictation/session lifecycle management and for communicating with the inference backend; the audio adapter focuses only on capture and preparation.
+- Preprocessing is optional and may be disabled when latency, power, or resource constraints are more important than audio enhancement.
+- A PipeWire- or PulseAudio-compatible audio server is installed on the target system.
+- The library runs in the same trusted process context as the dictation client; secure-field detection and user-visible error messages are handled by upstream components.
+- Audio data is treated as sensitive and is not persisted to disk by default.
+- Installing Canonical Workshop is the only permitted host prerequisite for the sandboxed test mode (constitution Principle IV); "sandboxed" means isolation of the audio stack and test state from the host, not a security boundary against malicious code.

--- a/specs/001-rust-audio-adapter/tasks.md
+++ b/specs/001-rust-audio-adapter/tasks.md
@@ -1,0 +1,235 @@
+# Tasks: Audio Adapter Library
+
+**Input**: Design documents from `specs/001-rust-audio-adapter/`
+
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/audio-adapter-api.md`, `quickstart.md`, `diagrams.md`
+
+**Tests**: Test tasks are REQUIRED and precede their implementation tasks (red-green TDD, constitution Principle I). Contract guarantees G1–G15 are defined in `contracts/audio-adapter-api.md`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. Cross-cutting phases (setup, foundational, sandbox regime, polish) carry no story label.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story label (US1, US2, US3) — user-story phases only
+- Include exact file paths in descriptions
+
+## Phase 1: Workspace, Sandbox, and Crate Setup
+
+**Purpose**: Cargo workspace, Workshop sandbox definition, crate scaffolding.
+
+- [ ] T001 Create root `Cargo.toml` workspace manifest including `crates/audio-adapter` member
+- [ ] T002 Create `crates/audio-adapter/Cargo.toml` with crate name `myna-audio-adapter`, default features `pipewire` + `pulse`, optional features `vad`, `denoise`, `async`, `test-util`
+- [ ] T003 [P] Create `workshop.yaml` at repo root — Canonical Workshop sandbox definition (constitution Principle IV, FR-021): Rust toolchain, `libpipewire-0.3-dev`/`libpulse-dev`/`clang`/`pkg-config`, `pipewire-utils`/`pulseaudio-utils`, virtual-audio provisioning, and a launch-time backend selection knob (`pipewire` default | `pulse`)
+- [ ] T004 [P] Create crate directory layout per plan.md: `crates/audio-adapter/src/` (stub modules), `tests/`, `tests/fixtures/`, `examples/`
+- [ ] T005 [P] Write `crates/audio-adapter/README.md` with system prerequisites for host builds and the Workshop sandbox flow (`workshop launch` / `workshop exec`) as the recommended path
+
+**Checkpoint**: `workshop launch` brings up the sandbox; empty crate builds inside it and on the host.
+
+---
+
+## Phase 2: Foundational Types and Contracts
+
+**Purpose**: Core data model and error/contract types every user story depends on (data-model.md).
+
+**⚠️ CRITICAL**: No user story implementation can begin until this phase is complete.
+
+- [ ] T006 [P] Implement `Error` enum in `crates/audio-adapter/src/error.rs` (`NoDevice`, `PermissionDenied`, `UnsupportedFormat`, `DeviceLost`, `Backend`) per FR-012
+- [ ] T007 [P] Implement `SampleFormat` and `AudioFormat` in `crates/audio-adapter/src/format.rs` with default target 16 kHz / mono / S16LE
+- [ ] T008 [P] Implement `NodeId` and `InputNode` in `crates/audio-adapter/src/node.rs` (`id`, `name`, `description`, `is_default`, `supported_formats`)
+- [ ] T009 [P] Implement `StreamConfig`, `PreprocessConfig`, `NodeSelector`, `BackendSelector` in `crates/audio-adapter/src/config.rs` with data-model.md validation rules (rate bounds, `max_buffer_duration` > 0, default 10 s)
+- [ ] T010 [P] Implement `AudioFrame`, `StreamEvent`, `StreamItem` in `crates/audio-adapter/src/frame.rs` with timing metadata and `seq`
+- [ ] T011 [P] Mark public enums (`Error`, `StreamEvent`, `StreamItem`) `#[non_exhaustive]` per contract §Stability
+
+**Checkpoint**: Foundational types compile; crate builds with `--no-default-features`.
+
+---
+
+## Phase 3: User Story 1 - Open an Audio Stream and Deliver Frames (Priority: P1) 🎯 MVP
+
+**Goal**: Stateless `enumerate_nodes()` / `open_stream()` facade delivering contiguous, artifact-free target-format frames, with overrun/underrun/device-loss semantics.
+
+**Independent Test**: With `MockBackend`, open a stream, read frames, force overrun/underrun/device-loss, close — asserting G2, G3, G4, G5, G7, G8, G9, G13, G15.
+
+### Tests for User Story 1 (write FIRST, observe them FAIL)
+
+- [ ] T012 [P] [US1] Create `MockBackend` in `crates/audio-adapter/src/backend/mock.rs` (feature `test-util`): feeds deterministic WAV fixtures, injects underrun gaps, format changes, and device-loss on command
+- [ ] T013 [P] [US1] Contract tests in `crates/audio-adapter/tests/contract.rs` for G7 (idempotent open), G8 (close releases ≤ 200 ms, buffers cleared), G9 (first frame ≤ 100 ms), G13 (no disk persistence)
+- [ ] T014 [P] [US1] Contract tests in `crates/audio-adapter/tests/contract.rs` for G3 (buffer full → oldest dropped, exactly one `Overrun{dropped}` per loss span, smoothed splice — assert no discontinuity above fade threshold) and G4 (server gap → silence fill keeps `seq`/timestamps continuous, one `Underrun{filled}` event, smoothed fill boundaries) per FR-014/FR-015/FR-018
+- [ ] T015 [P] [US1] Consumer-scenario test in `crates/audio-adapter/tests/consumer_scenario.rs` (G15, FR-020): replay the Speech Controller call pattern from contracts §Known consumer — enumerate → open → timed read loop matching `Frame`/`DeviceLost`/`Overrun` items → close — against `MockBackend` (extended with `VoiceActivity` handling in US3)
+- [ ] T016 [US1] Integration tests in `crates/audio-adapter/tests/integration.rs` (gated: `MYNA_AUDIO_IT=1` + `#[ignore]`): node enumeration with metadata, idempotent open on a real server, device-lost via virtual-node removal (G5), `NoDevice` on nonexistent node
+
+### Implementation for User Story 1
+
+- [ ] T017 [US1] Define `AudioBackend` trait and auto-probe (PipeWire → Pulse) in `crates/audio-adapter/src/backend/mod.rs`
+- [ ] T018 [US1] Implement PipeWire backend in `crates/audio-adapter/src/backend/pipewire.rs`: registry-based node enumeration, server-side format negotiation (FR-009), RT capture callback, device-lost detection
+- [ ] T019 [US1] Implement PulseAudio fallback backend in `crates/audio-adapter/src/backend/pulse.rs`: source enumeration, capture stream, device-lost detection
+- [ ] T020 [US1] Implement bounded SPSC ring buffer in `crates/audio-adapter/src/ring.rs`: drop-oldest on overflow, loss-span accounting, raised-cosine splice smoothing (FR-014/FR-015)
+- [ ] T021 [US1] Implement underrun detection and silence fill with smoothed boundaries + `Underrun` events in the capture path (`ring.rs`/backend modules) per FR-018
+- [ ] T022 [US1] Implement `AudioStream` in `crates/audio-adapter/src/stream.rs` (`read`, `read_timeout`, `close`, `node`, `target_format`) draining frames and interleaved events in timeline order
+- [ ] T023 [US1] Implement public facade in `crates/audio-adapter/src/lib.rs` (`enumerate_nodes`, `open_stream` with idempotent per-node handle lookup per FR-003)
+
+**Checkpoint**: US1 contract, consumer-scenario, and integration tests pass; MVP demonstrable.
+
+---
+
+## Phase 4: User Story 2 - Resample and Format-Convert to STT-Compatible Audio (Priority: P2)
+
+**Goal**: Any supported source format converts to the configured target; mid-stream renegotiation is transparent.
+
+**Independent Test**: Feed a 48 kHz stereo fixture through the pipeline; every output frame is 16 kHz mono S16LE (G1), timeline contiguous (G2), renegotiation transparent (G6).
+
+### Tests for User Story 2 (write FIRST, observe them FAIL)
+
+- [ ] T024 [P] [US2] Add WAV fixtures to `crates/audio-adapter/tests/fixtures/` (`speech_48k_stereo.wav`, `speech_16k_mono.wav`, format-change sequence)
+- [ ] T025 [P] [US2] Contract tests in `crates/audio-adapter/tests/contract.rs` for G1 (exact target-format match), G2 (contiguity across conversion), G6 (mid-stream renegotiation continues; `UnsupportedFormat` only when unconvertible)
+- [ ] T026 [P] [US2] Resampling-quality test in `crates/audio-adapter/src/convert/resample.rs` (unit): `rubato` output vs high-quality reference resample of a fixture, total sample error < 1% over the clip (SC-002)
+- [ ] T027 [US2] Integration test in `crates/audio-adapter/tests/integration.rs`: capture from a 48 kHz stereo virtual node, assert 16 kHz mono delivery
+
+### Implementation for User Story 2
+
+- [ ] T028 [P] [US2] Sample-format and channel-mixdown conversion in `crates/audio-adapter/src/convert/channels.rs`
+- [ ] T029 [US2] `rubato`-based fallback resampler in `crates/audio-adapter/src/convert/resample.rs` (allocation-free in steady state)
+- [ ] T030 [US2] Conversion pipeline in `crates/audio-adapter/src/convert/mod.rs`: bypass when the server delivers target format, in-process convert otherwise
+- [ ] T031 [US2] Wire conversion into the `AudioStream` production path so every read yields target-format frames
+- [ ] T032 [US2] Transparent mid-stream renegotiation in backends + convert pipeline (FR-017)
+
+**Checkpoint**: US2 tests pass; US1 suite still green over converted output.
+
+---
+
+## Phase 5: User Story 3 - Optional Preprocessing for Better Transcription Quality (Priority: P3)
+
+**Goal**: Feature-gated denoise and VAD stages chained before delivery; pass-through untouched when disabled.
+
+**Independent Test**: Run stages on noisy fixtures — non-speech attenuated, `VoiceActivity` transitions fire (G11); disabled preprocessing adds no latency stage (G12).
+
+### Tests for User Story 3 (write FIRST, observe them FAIL)
+
+- [ ] T033 [P] [US3] Add noisy/reverberant fixtures (`noisy_speech.wav`, silence-bounded utterances) to `crates/audio-adapter/tests/fixtures/`
+- [ ] T034 [P] [US3] Unit tests for the denoise stage in `crates/audio-adapter/src/preprocess/denoise.rs` (non-speech RMS reduced, speech intact)
+- [ ] T035 [P] [US3] Unit tests for the VAD stage in `crates/audio-adapter/src/preprocess/vad.rs` (transition events at fixture speech boundaries)
+- [ ] T036 [US3] Contract tests in `crates/audio-adapter/tests/contract.rs` for G11 (VAD events on speech stop) and G12 (pass-through when disabled); extend `tests/consumer_scenario.rs` with `VoiceActivity` utterance-chunking handling (G15)
+
+### Implementation for User Story 3
+
+- [ ] T037 [US3] Define `PreprocessStage` trait and stage chain in `crates/audio-adapter/src/preprocess/mod.rs`
+- [ ] T038 [P] [US3] Implement RNNoise denoise stage (`nnnoiseless`, feature `denoise`) in `crates/audio-adapter/src/preprocess/denoise.rs`
+- [ ] T039 [P] [US3] Implement Silero VAD stage (feature `vad`) in `crates/audio-adapter/src/preprocess/vad.rs`, emitting `StreamEvent::VoiceActivity`
+- [ ] T040 [US3] Wire the chain into `AudioStream` per `StreamConfig.preprocess`
+- [ ] T041 [US3] Document `DeverbStage` deferral in `crates/audio-adapter/src/preprocess/mod.rs` (FR-011 MAY; non-breaking future stage)
+- [ ] T042 [US3] SC-005 accuracy benchmark: define reference noisy/reverberant corpus + STT harness (or reference the myna testbed corpus) in `crates/audio-adapter/benches/accuracy.md` procedure doc; run baseline vs preprocessed, record results
+
+**Checkpoint**: US3 green with `--features vad,denoise`; US1/US2 green with and without preprocessing.
+
+---
+
+## Phase 6: Async Adapter and Examples
+
+**Purpose**: Optional async interface and the quickstart's runnable conformance examples.
+
+- [ ] T043 [P] Implement `futures::Stream` adapter (feature `async`) in `crates/audio-adapter/src/async_stream.rs` with a smoke test
+- [ ] T044 Create `crates/audio-adapter/examples/capture_check.rs`: measure first-frame latency, steady-state lag, close/release time; non-zero exit outside SC-001/SC-003/SC-004 targets
+- [ ] T045 Create `crates/audio-adapter/examples/preprocess_check.rs`: VAD/denoise validation on a fixture file per quickstart
+- [ ] T046 [P] Add fixture-generation script + docs in `crates/audio-adapter/tests/fixtures/README.md`
+
+---
+
+## Phase 7: Sandboxed Test Regime (FR-021/FR-022)
+
+**Purpose**: Make the Workshop sandbox the working, verified test environment across both backends.
+
+- [ ] T047 Declare per-backend test subsets (FR-021 clarification): tag PipeWire-only tests (native node enumeration, session-manager routing) vs common tests via test-name convention or feature flags; check in the subset declaration in `crates/audio-adapter/tests/README.md`; ensure results record the backend exercised
+- [ ] T048 Backend-matrix sandbox runs: `workshop launch` with PipeWire and with PulseAudio; each backend passes 100% of its declared subset (SC-007), including the `speech_controller_session_flow` integration variant of the consumer-scenario test against the virtual node
+- [ ] T049 Host-isolation and teardown verification (SC-008, FR-022): snapshot host audio devices/daemons before/during/after a sandboxed run — zero changes; after teardown no processes, devices, or files remain on the host
+- [ ] T050 Offline-after-provisioning check (FR-022): after initial provisioning cache, relaunch sandbox and run the suites with network disabled — all pass
+- [ ] T051 Environment-vs-test failure distinction (FR-022): sandbox entry points exit with distinct, documented codes/messages for provisioning failures (Workshop missing, virtualization unavailable, backend failed to start) vs test failures
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, quality gates, performance watermarks, release readiness.
+
+- [ ] T052 [P] Write crate-level rustdoc in `crates/audio-adapter/src/lib.rs`, including the Speech Controller consumer-surface section mirroring contracts §Known consumer (FR-020)
+- [ ] T053 Verify and update `specs/001-rust-audio-adapter/diagrams.md` against as-built behavior (FR-019) — this is the single canonical diagram location; do not create a second copy under `crates/`
+- [ ] T054 Performance watermark baselines (constitution Principle III): measure peak/steady-state memory, CPU, end-to-end latency, and buffer occupancy in the Workshop container and sandbox VM profile; check in baselines with declared per-metric tolerances under `crates/audio-adapter/benches/watermarks/`; add a tolerance-checked regression test wired into the suite
+- [ ] T055 [P] Run `cargo clippy --all-features -- -D warnings` and fix all issues
+- [ ] T056 Run the full matrix: `--no-default-features`, `--all-features`, and feature combos; full suite incl. `MYNA_AUDIO_IT=1` integration
+- [ ] T057 Privacy checks: `strace` no-audio-write sweep and `unshare -n` network-free run per quickstart (FR-007, SC-006, G13/G14)
+- [ ] T058 Add `CHANGELOG.md` entry for the new crate
+- [ ] T059 Verify `quickstart.md` executes exactly as documented — sandbox flow first, host flows second
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: none — start immediately; T003 (`workshop.yaml`) unblocks all sandboxed gates.
+- **Phase 2 (Foundational)**: after Phase 1; BLOCKS all user stories.
+- **Phase 3 (US1)**: after Phase 2 — MVP.
+- **Phase 4 (US2)**: after Phase 2; end-to-end paths consume US1's stream/ring.
+- **Phase 5 (US3)**: after Phase 2; stage unit tests independent, end-to-end needs US2.
+- **Phase 6 (Async/Examples)**: after US1 (capture_check), US3 (preprocess_check).
+- **Phase 7 (Sandbox regime)**: T047 after US1 tests exist; T048–T051 after the suites they run (full value after Phase 6).
+- **Phase 8 (Polish)**: after all prior phases; T054 needs the sandbox (Phase 7).
+
+### Within Each User Story
+
+- Tests written and observed failing before implementation (constitution Principle I).
+- US1: mock/trait → backends → ring/stream → facade.
+- US2: channels → resampler → pipeline → stream wiring → renegotiation.
+- US3: trait → stages → chain wiring.
+
+### Parallel Opportunities
+
+- Phase 1: T003, T004, T005 in parallel after T001/T002.
+- Phase 2: T006–T011 all parallel.
+- US1: T012–T015 (test files) parallel; T018 and T019 (two backends) parallel after T017.
+- US2: T024–T026 parallel; T028 parallel with T029.
+- US3: T033–T035 parallel; T038 and T039 parallel after T037.
+- Phase 8: T052, T055 parallel with each other.
+
+---
+
+## Implementation Strategy
+
+### Branch Staging Plan (constitution "Staged Delivery in Feature Branches")
+
+| # | Branch | Scope (phases/stories) | Prerequisite branches | Merge gates |
+|---|--------|------------------------|-----------------------|-------------|
+| 1 | `001-audio-foundation` | Phase 1–2 (workspace, `workshop.yaml`, foundational types) | — | crate builds (host + sandbox smoke: `workshop launch` succeeds); hermetic type tests |
+| 2 | `001-audio-us1-capture` | Phase 3 (US1 tests + implementation) | #1 | hermetic contract + consumer-scenario suites; sandbox integration, PipeWire subset |
+| 3 | `001-audio-us2-convert` | Phase 4 (US2) | #2 | hermetic suites; sandbox integration incl. 48 kHz virtual-node conversion |
+| 4 | `001-audio-us3-preprocess` | Phase 5 (US3) | #3 | hermetic suites with `--features vad,denoise`; SC-005 benchmark recorded |
+| 5 | `001-audio-async-examples` | Phase 6 | #4 | hermetic suites; `capture_check`/`preprocess_check` conformance in sandbox |
+| 6 | `001-audio-sandbox-matrix` | Phase 7 (subsets, backend matrix, isolation/offline checks) | #5 | both backend subsets 100% green (SC-007); isolation (SC-008) + offline checks pass |
+| 7 | `001-audio-polish-watermarks` | Phase 8 | #6 | full feature matrix; watermark baselines checked in, tolerance test green; privacy checks |
+
+Each branch carries its increment's tests and implementation together and leaves `main` green at merge; no branch builds on unmerged sibling work.
+
+### MVP First (User Story 1 Only)
+
+1. Branches 1–2 (Setup + Foundational + US1).
+2. **STOP and VALIDATE**: contract + consumer-scenario suites, `capture_check` in the sandbox.
+3. Demo capture/streaming.
+
+### Incremental Delivery
+
+Branch-by-branch per the staging plan: each merge is an independently tested increment (capture → conversion → preprocessing → examples → sandbox matrix → watermarks/polish).
+
+### Parallel Team Strategy
+
+After branch 1 merges: Developer A takes US1 backends (T018/T019 parallel), Developer B prepares US2 conversion tests/impl on a branch stacked on #2, Developer C prepares US3 stages (unit-testable against the trait). Branches still merge in staging-plan order.
+
+---
+
+## Notes
+
+- **Feature flags**: `pipewire` + `pulse` default; `vad`, `denoise`, `async`, `test-util` optional. CI tests `--no-default-features`, `--all-features`, and per-feature combos (T056).
+- **Integration tests**: gated behind `MYNA_AUDIO_IT=1` + `#[ignore]`; hermetic `cargo test` needs no audio server. Per-backend subsets are explicitly declared (T047) — PipeWire-only tests do not run under the PulseAudio selection.
+- **Test-first**: contract tests for G1–G15 exist and fail before the implementations they assert; `MockBackend` keeps user stories progressing without a live audio server.
+- **Sandbox-first**: the Workshop sandbox (T003) is the reference environment — reviewers should be able to reproduce every gate with `workshop launch` + `workshop exec`.
+- **No disk persistence / offline**: verified by T057 (host) and T050 (sandbox).
+- **Deferred deverb**: FR-011 (MAY) documented as a future `PreprocessStage` (T041).


### PR DESCRIPTION
## What

Design artifacts for the audio adapter library (`specs/001-rust-audio-adapter/`): specification with 13 recorded clarifications, implementation plan (Rust workspace, PipeWire-primary/PulseAudio-fallback), research decisions, data model, API contract with 15 testable guarantees and the Speech Controller consumer surface, architecture/sequence diagrams, quickstart validation guide, and the 59-task breakdown staged into 7 feature branches.

## Why

Fixes the library's behavioral contract before implementation: capture semantics (overrun/underrun/device-loss policies), format conversion guarantees, the exact API surface the Speech Controller consumes, and a Workshop-sandboxed test regime covering both PipeWire and PulseAudio backends.

Stacked: #8 (spec-kit tooling) ← this PR ← #7 (implementation).